### PR TITLE
h26x_extractor: add deeper slice_header parsing

### DIFF
--- a/h26x_extractor/h26x_parser.py
+++ b/h26x_extractor/h26x_parser.py
@@ -174,6 +174,8 @@ class H26xParser:
         """
 
         self._get_nalu_positions()
+        nalu_sps = None
+        nalu_pps = None
         for current_nalu_pos, next_nalu_pos in zip(self.nal_unit_positions, islice(self.nal_unit_positions, 1, None)):
             current_nalu_bytepos = int(current_nalu_pos / 8)
             next_nalu_bytepos = int(next_nalu_pos / 8)
@@ -209,8 +211,8 @@ class H26xParser:
                 aud = nalutypes.AUD(rbsp_payload, self.verbose)
                 self.__call('aud', rbsp_payload)
             elif nal_unit_type == nalutypes.NAL_UNIT_TYPE_CODED_SLICE_NON_IDR:
-                nalu_slice = nalutypes.CodedSliceNonIDR(rbsp_payload, self.verbose)
+                nalu_slice = nalutypes.CodedSliceNonIDR(rbsp_payload, nalu_sps, nalu_pps, self.verbose)
                 self.__call('slice', rbsp_payload)
             elif nal_unit_type == nalutypes.NAL_UNIT_TYPE_CODED_SLICE_IDR:
-                nalu_slice = nalutypes.CodedSliceIDR(rbsp_payload, self.verbose)
+                nalu_slice = nalutypes.CodedSliceIDR(rbsp_payload, nalu_sps, nalu_pps, self.verbose)
                 self.__call('slice', rbsp_payload)


### PR DESCRIPTION
Includes:
* passing the SPS and PPS NALUs to CodedSliceIDR and CodedSliceNonIDR
  (which need them to go further)
* adding an optional concept of order in the verbose printing, so that
  NALU parameters are printed in the order they are parsed
* implementing ordering in SPS, PPS, and CodedSliceIDR NALUs
* fix on the SPS parser based on profile_idc values, per 2016-02
  standard (Section 7.3.2.1.1, page 44). Note in particular that the if
  loop does not include value 144
* fix minor type (s/slice_gropu_change_rate_minus1/slice_group_change_rate_minus1/)

Tested:
```
$ h26x-extractor -v file.264
...
SPS (payload size: 21.0 Bytes)
+--------------------------------------+---------+
| field                                | value   |
+======================================+=========+
| profile_idc                          | 66      |
+--------------------------------------+---------+
| constraint_set0_flag                 | 1       |
+--------------------------------------+---------+
| constraint_set1_flag                 | 1       |
+--------------------------------------+---------+
| constraint_set2_flag                 | 0       |
+--------------------------------------+---------+
| constraint_set3_flag                 | 0       |
+--------------------------------------+---------+
...
NALU type:  5 (Coded slice of an IDR picture)
NALU bytes: 0x000000016588841afffffc2f14000416fd78e06380de6a1306bb224a722233e54ffa7cb9526c188ed1189699e7c6fd1a2307f757de5c3fca2f3d22b7fc667ccb6ff6b6a8dabb515b59fe53f8a7d83a8beb6ff17988adbfde818bdf2dafc5e7a2b5fde4a0bca4156137f8ceadff19bd5bfe233e152fbefbefbe2fab6dfe...
NALU RBSP:  0x88841afffffc2f14000416fd78e06380de6a1306bb224a722233e54ffa7cb9526c188ed1189699e7c6fd1a2307f757de5c3fca2f3d22b7fc667ccb6ff6b6a8dabb515b59fe53f8a7d83a8beb6ff17988adbfde818bdf2dafc5e7a2b5fde4a0bca4156137f8ceadff19bd5bfe233e152fbefbefbe2fab6dfed6d62d6ad7...

CodedSliceIDR (payload size: 4538.0 Bytes)
+----------------------+---------+
| field                | value   |
+======================+=========+
| first_mb_in_slice    | 0       |
+----------------------+---------+
| slice_type           | 7       |
+----------------------+---------+
| slice_type_clear     | I       |
+----------------------+---------+
| pic_parameter_set_id | 0       |
+----------------------+---------+
| frame_num            | 0       |
+----------------------+---------+
| field_pic_flag       | 1       |
+----------------------+---------+
| bottom_field_flag    | 0       |
+----------------------+---------+
| idr_pic_id           | 25      |
...
```